### PR TITLE
Refactor table ui

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -53,34 +53,25 @@
         :empty-text="messages.empty_list"
         style="width: 100%"
       >
-        <el-table-column
+        <el-table-column min-width="200"
         :label="capitalizeFirstLetter(this.itemType)"
          prop="name"
         >
         </el-table-column>
-        <el-table-column label="Status" align="center">
+        <el-table-column label="Availability" align="center">
           <template slot-scope="scope">
             <el-tooltip v-if="(scope.row.borrower)" class="item" effect="dark" :content="messages.tooltip.unavailable" placement="right">
-              <i class="el-icon-error" style="font-size:18px; color: #F56C6C;"></i>
+              <div>
+                <i class="el-icon-error" style="font-size:18px; color: #F56C6C;"></i>
+                <div>({{ scope.row.borrower }})</div>
+              </div>
             </el-tooltip>
             <el-tooltip v-else class="item" effect="dark" :content="messages.tooltip.available" placement="right">
               <i class="el-icon-success" style="font-size:18px; color: #67C23A;"></i>
             </el-tooltip>
           </template>
         </el-table-column>
-        <el-table-column label="Borrower">
-          <template slot-scope="scope">
-            {{ scope.row.borrower }}
-          </template>
-        </el-table-column>
-        <el-table-column align="right">
-          <template slot="header" slot-scope="scope">
-            <el-input
-              v-model="search"
-              size="small"
-              placeholder="Type to search..."
-            />
-          </template>
+        <el-table-column align="center" label="Action">
           <template slot-scope="scope">
             <!-- Start Admin Permission -->
             <div v-if="$route.query.role === 'admin'">
@@ -362,7 +353,8 @@ export default {
 <style>
 
 .el-table .cell {
-  white-space: nowrap;
+  line-height: 1.4;
+  word-break: normal;
 }
 
 .el-form-item__label {


### PR DESCRIPTION
สวัสดี commee

อยากจะปรับปรุง UI ของเดิม โฟกัสที่ mobile layout ที่เจอ issue ประมาณนี้

1. ชื่อหนังสือโดนตัด ทำให้ไม่เห็นชื่อเต็มๆ ของหนังสือ
2. มี empty space เยอะที่ไม่ได้ใช้ประโยชน์
3. search input อยู่ตรง table header พี่ว่ามันอยู่ผิดที่ไปหน่อย

![original](https://user-images.githubusercontent.com/911894/105732599-345f6480-5f63-11eb-869c-f242035db90d.png)

เสนอทางปรับปรุง

1. เอา `white-space: nowrap` ออก เพื่อให้คอลัมน์แรกมันไม่ตัดชื่อหนังสือด้วย `...` และก็เพิ่มขนาด column ของชื่อหนังสือให้ min-width ที่ 200px. ปรับ `line-height` นิดหน่อยให้แยก data แต่ละ row ได้ชัดเจนขึ้น
2. เอาคอลัมน์ Borrower ออกไปทั้งหมดเลย เพราะตอนนี้คน borrow น้อยมากจนทำให้เสีย column ไปกับ space ว่างๆ เสนอว่าเอาไปรวมกับ status ได้
3. เอาชื่อ borrower มารวมกับ status แล้วแสดงชื่อ borrower ไว้ข้างใต้ status icon ถ้าหนังสือเล่มนั้นถูกยืมไป (โดยใคร) ในวงเล็บแทน
4. search input อาจยังไม่จำเป็นตอนนี้ เพราะ 1) จำนวนหนังสือน้อย - scroll ขึ้นลง หรือการทำให้ table มัน sort ได้ อาจจะหาหนังสือเจอง่ายกว่าการพิมพ์ในช่อง search และ 2) มันมองเห็นไม่ชัดว่ามีช่อง search อยู่ตรงนั้น และplaceholder มันก็แสดงไม่เต็มอยู่ดี เพราะ column มันแคบ ก็เลยเสนอว่าเอาออกไปก่อน และหาทางทำให้มันใช้ง่ายกว่านี้ดีกว่า
5.  เปลี่ยน label `Status` เป็น `Availability` - คิดว่าสื่อความหมายกับ icon ที่ใช้ได้ดีกว่า แต่จริงๆ ก็ไม่ชอบคำว่า availability เท่าไหร่เพราะมันยาว ยังคิดคำอื่นไม่ออก

after:

![after](https://user-images.githubusercontent.com/911894/105735283-1a735100-5f66-11eb-9bb0-ce81438134cf.png)


![localhost_3000_(iPhone X) (2)](https://user-images.githubusercontent.com/911894/105734864-a9339e00-5f65-11eb-9855-abf54ebfedc7.png)

