### PR TITLE
Feature/tiny features

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -37,7 +37,8 @@ export default {
 
   // Plugins to run before rendering page (https://go.nuxtjs.dev/config-plugins)
   plugins: [
-    '@/plugins/element-ui'
+    '@/plugins/element-ui',
+    '@/plugins/filters'
   ],
 
   // Auto import components (https://go.nuxtjs.dev/config-components)

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,6 +1,6 @@
 <template>
   <el-row type="flex" justify="center">
-    <el-col :span="18" :xs="23">
+    <el-col :span="18" :xs="22">
       <div style="margin-top: 60px;">
           <img width="50" height="50" src="~/assets/icon.png" style="margin-top:-6px; margin-left:5px;"/>
           <el-tooltip effect="dark" content="Device Tracking" placement="top">
@@ -116,17 +116,10 @@
         :visible.sync="showBorrowInformationDialog"
         @opened="setAutoFocus"
         >
-        <el-form :model="borrowInformationForm" @submit.native.prevent>
-          <el-form-item label="Item ID: " :label-width="formLabelWidth">
-            {{ borrowInformationForm.id }}
-          </el-form-item>
-          <el-form-item
-          label="Name: "
-          :label-width="formLabelWidth"
-          style="white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
-            {{ borrowInformationForm.name }}
-          </el-form-item>
-          <el-form-item label="Borrower : " :label-width="formLabelWidth">
+        <el-form :model="borrowInformationForm"
+          label-position="top"
+          @submit.native.prevent>
+          <el-form-item label="Your name: " :label-width="formLabelWidth">
             <el-input
               ref="borrower"
               size="medium"
@@ -137,6 +130,9 @@
             </el-input>
           </el-form-item>
         </el-form>
+        <div slot="title" class="dialog-text">
+          Borrowing <em>{{ borrowInformationForm.name }}</em>.
+        </div>
         <span slot="footer" class="dialog-footer">
           <el-button @click="showBorrowInformationDialog = false">Cancel</el-button>
           <el-button
@@ -357,16 +353,26 @@ export default {
 
 .el-form-item__label {
   text-align: left;
+  line-height: 1;
 }
 
 @media only screen and (max-width: 768px) {
-  .el-form-item__label {
-    width: 25% !important;
-  }
-
   .borrow-information {
     width: 95%;
   }
+}
+
+.dialog-text {
+  font-size: 1.2rem;
+}
+
+.dialog-text em {
+  font-weight: bold;
+}
+
+.el-dialog__body {
+  padding-top: 20px;
+  padding-bottom: 0;
 }
 
 </style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -56,7 +56,7 @@
       >
         <el-table-column min-width="200"
         sortable
-        :label="capitalizeFirstLetter(this.itemType)"
+        :label="this.itemType | capitalize"
          prop="name"
         >
         </el-table-column>
@@ -117,11 +117,11 @@
         @opened="setAutoFocus"
         >
         <el-form :model="borrowInformationForm" @submit.native.prevent>
-          <el-form-item label="Item ID : " :label-width="formLabelWidth">
+          <el-form-item label="Item ID: " :label-width="formLabelWidth">
             {{ borrowInformationForm.id }}
           </el-form-item>
           <el-form-item
-          label="Item : "
+          label="Name: "
           :label-width="formLabelWidth"
           style="white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
             {{ borrowInformationForm.name }}
@@ -318,10 +318,6 @@ export default {
       this.borrowInformationForm.name = data.name;
       this.borrowInformationForm.type = '';
       this.showBorrowInformationDialog = true;
-    },
-
-    capitalizeFirstLetter(string) {
-      return string.replace(/^./, string[0].toUpperCase());
     },
 
     setAutoFocus() {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -6,7 +6,7 @@
           <el-tooltip effect="dark" content="Device Tracking" placement="top">
             <el-button
             style="float: right;"
-            type="primary"
+            :type="this.itemType === 'devices' ? 'primary' : ''"
             icon="el-icon-mobile-phone"
             circle
             @click="getItemType('devices')"
@@ -16,7 +16,7 @@
           <el-tooltip effect="dark" content="Book Tracking" placement="top">
             <el-button
             style="float: right; margin-right:20px;"
-            type="primary"
+            :type="this.itemType === 'books' ? 'primary' : ''"
             icon="el-icon-notebook-1"
             circle
             @click="getItemType('books')"

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -50,10 +50,12 @@
       <el-table
         v-else
         :data="filterData(itemList)"
+        :default-sort="{prop: 'name'}"
         :empty-text="messages.empty_list"
         style="width: 100%"
       >
         <el-table-column min-width="200"
+        sortable
         :label="capitalizeFirstLetter(this.itemType)"
          prop="name"
         >

--- a/plugins/filters.js
+++ b/plugins/filters.js
@@ -1,0 +1,4 @@
+import Vue from 'vue'
+
+Vue.filter('capitalize', (string) => string.replace(/^./, string[0].toUpperCase()))
+Vue.filter('singularize', (string) => string.slice(0, -1))


### PR DESCRIPTION
1. Datatable: Make data table sortable by book/device names เผื่อจะหาง่ายขึ้นหน่อย
2. Mode selector: Set primary color to only the current `itemType` to make it more clear which one is active.
3. Layout: Use 22 columns for xs layout instead of 3 to add some spaces on the left and right. ก่อนหน้านี้มันชิดขอบไปหน่อย
4. Borrow dialog: display item name in the dialog header, remove id and name fields.
5. (refactor) Create filters to transform strings. Rename `capitalizeFirstLetter` to just `capitalize` because [capitalize is already = just the first letter](https://en.wikipedia.org/wiki/Capitalization#:~:text=Capitalization%20(North%20American%20English)%20or,systems%20with%20a%20case%20distinction.&text=The%20rules%20have%20also%20changed,generally%20to%20capitalize%20fewer%20words.).

![layout](https://user-images.githubusercontent.com/911894/106392275-a59b8d80-6423-11eb-93e4-d9d19adb6f8b.png)

![Screen Shot 2021-02-01 at 00 08 01](https://user-images.githubusercontent.com/911894/106392301-c2d05c00-6423-11eb-8ac9-11cdf7a04c36.png)

